### PR TITLE
S3 savings fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tinystacks/ops-aws-utilization-widgets",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tinystacks/ops-aws-utilization-widgets",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@aws-sdk/client-account": "^3.315.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinystacks/ops-aws-utilization-widgets",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "dist/index.js",
   "type": "module",
   "files": [

--- a/src/service-utilizations/aws-s3-utilization.tsx
+++ b/src/service-utilizations/aws-s3-utilization.tsx
@@ -196,19 +196,14 @@ export class s3Utilization extends AwsServiceUtilization<s3UtilizationScenarios>
       * Uses arbitrary percentages to separate amount of data in tiers
       */
 
-      let totalBytes = bucketBytes;
-      let infrequentlyAccessedBytes = 0.4 * bucketBytes;
-      let archiveInstantAccess = 0.4 * infrequentlyAccessedBytes;
-      let archiveAccess = 0.4 * archiveInstantAccess;
-      const deepArchiveAccess = 0.4 * archiveAccess;
-
-      totalBytes = (totalBytes - infrequentlyAccessedBytes) / ONE_GB_IN_BYTES;
-      infrequentlyAccessedBytes = (infrequentlyAccessedBytes - archiveInstantAccess) / ONE_GB_IN_BYTES;
-      archiveInstantAccess = (archiveInstantAccess - archiveAccess) / ONE_GB_IN_BYTES;
-      archiveAccess = (archiveAccess - deepArchiveAccess) / ONE_GB_IN_BYTES;
+      const frequentlyAccessedBytes = (0.5 * bucketBytes) / ONE_GB_IN_BYTES;
+      const infrequentlyAccessedBytes = (0.25 * bucketBytes) / ONE_GB_IN_BYTES;
+      const archiveInstantAccess = (0.1 * bucketBytes) / ONE_GB_IN_BYTES;
+      const archiveAccess = (0.1 * bucketBytes) / ONE_GB_IN_BYTES;
+      const deepArchiveAccess = (0.05 * bucketBytes) / ONE_GB_IN_BYTES;
 
       const newMonthlyCost = 
-        (totalBytes * 0.022) +
+        (frequentlyAccessedBytes * 0.022) +
         (infrequentlyAccessedBytes * 0.0125) +
         (archiveInstantAccess * 0.004) +
         (archiveAccess * 0.0036) +


### PR DESCRIPTION
## Pull Request Type
 - [ ] Feature
 - [x] Bug Fix

## Summary of Bug Fix(es)
### Previous Behaviour
_Description of the bug and it's impact_
- fixed convoluted savings calculation that could inaccurately calculate higher new cost than existing cost